### PR TITLE
Redirect HTTP to HTTPS

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,16 @@ func main() {
 
 	r := gin.New()
 
+	r.Use(func(c *gin.Context) {
+		if c.GetHeader("X-Forwarded-Proto") == "http" {
+			target := "https://" + c.Request.Host + c.Request.RequestURI
+			c.Redirect(http.StatusMovedPermanently, target)
+			c.Abort()
+			return
+		}
+		c.Next()
+	})
+
 	apiRouter := r.Group("/api/v0")
 	apiv0.NewAPIv0(apiRouter, db)
 


### PR DESCRIPTION
## Summary

- Adds Gin middleware to redirect `http://` requests to `https://` via Heroku's `X-Forwarded-Proto` header

## Why

Heroku terminates SSL at the load balancer and forwards requests to the app over plain HTTP, setting `X-Forwarded-Proto: http`. Without this middleware, visiting the `http://` URL serves the site over HTTP rather than redirecting.

## Test plan

- [ ] `curl -I http://dublinbikeparking.com` returns `301` to `https://dublinbikeparking.com`
- [ ] `curl -I https://dublinbikeparking.com` returns `200` as normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)